### PR TITLE
Update the example to show the new digest function directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,12 @@ direct access to your cluster's Content Addressable Storage, at least
 until your token expires or bb\_clientd restarts.
 
 The FUSE/NFSv4 file system provided by bb\_clientd automatically
-generates a "blobs" directory for every instance name provided:
+generates a "blobs" directory for every instance name and digest function provided:
 
 ```
-$ ls -l ~/bb_clientd/cas/mycluster-prod.example.com/hello/blobs
+$ ls ~/bb_clientd/cas/mycluster-prod.example.com/hello/blobs/
+md5/  sha1/  sha256/  sha256tree/  sha384/  sha512/
+$ ls -l ~/bb_clientd/cas/mycluster-prod.example.com/hello/blobs/sha256
 total 0
 d--x--x--x  1 root  wheel  0 Jan  1  2000 directory
 d--x--x--x  1 root  wheel  0 Jan  1  2000 executable

--- a/configs/bb_clientd.jsonnet
+++ b/configs/bb_clientd.jsonnet
@@ -129,7 +129,7 @@ local cacheDirectory = homeDirectory + '/.cache/bb_clientd';
       } } },
       labels: {
         // Let the local CAS consume up to 100 GiB of disk space. A 64
-        // MiB index is large enough to accomodate approximately one
+        // MiB index is large enough to accommodate approximately one
         // million objects.
         localCAS: { 'local': {
           keyLocationMapOnBlockDevice: { file: {


### PR DESCRIPTION
The blobs directory now contain a list of the new digest functions, and the mentioned directories are located one level deeper. With similar permissions so I picked the succinct `ls` without `-l`.