### PR TITLE
Fix panic for unimplemented ApplyGetContainingDigests

### DIFF
--- a/pkg/filesystem/virtual/bazel_output_service_directory.go
+++ b/pkg/filesystem/virtual/bazel_output_service_directory.go
@@ -184,7 +184,9 @@ func (d *BazelOutputServiceDirectory) filterMissingChildren(ctx context.Context,
 		// this file or directory depends.
 		var p virtual.ApplyGetContainingDigests
 		if !node.GetNode().VirtualApply(&p) {
-			panic("output path contains nodes that don't support ApplyGetContainingDigests")
+			// This node type does not depend on any digests, e.g. a file in the
+			// file pool.
+			return true
 		}
 		if p.Err != nil {
 			// Can't compute the set of digests underneath


### PR DESCRIPTION
bb-storage refactored `VirtualApply()` of `ApplyGetContainingDigests` to return false instead of an empty set. This was done in [bb-remote-execution commit 4983b382e9b368ae4212e78ad861ddaa626d1002](https://github.com/buildbarn/bb-remote-execution/commit/4983b382e9b368ae4212e78ad861ddaa626d1002): "Remove bogus implementations of ApplyGetContainingDigests".