### PR TITLE
At dpkg postinst, ask for reboot instead of killing desktop

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
 build --host_cxxopt=-std=c++17
-run --workspace_status_command="bash tools/workspace-status.sh"
+build --workspace_status_command="bash tools/workspace-status.sh"

--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -192,7 +192,7 @@
             },
             {
                "name": "linux_amd64: build bb_clientd.deb",
-               "run": "bazel build --platforms=@rules_go//go/toolchain:linux_amd64 //:bb_clientd_deb"
+               "run": "bazel build --stamp --platforms=@rules_go//go/toolchain:linux_amd64 //:bb_clientd_deb"
             },
             {
                "name": "linux_amd64: copy bb_clientd.deb",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@gazelle//:def.bzl", "gazelle")
 load("@rules_pkg//:pkg.bzl", "pkg_deb", "pkg_tar")
 
@@ -35,15 +36,30 @@ pkg_tar(
     },
 )
 
+# When built with --stamp, creates a non-deterministic output file for pushing images to a remote registry.
+# With --nostamp, produces a deterministic output so dependents get cache hits.
+expand_template(
+    name = "deb_version_file",
+    out = "_deb_version.txt",
+    stamp_substitutions = {"_TAG_": "{{BUILD_SCM_TIMESTAMP}}-{{BUILD_SCM_REVISION}}"},
+    substitutions = {"_TAG_": "0~unknown"},
+    template = ["_TAG_"],
+    visibility = ["//visibility:public"],
+)
+
 pkg_deb(
     name = "bb_clientd_deb",
-    architecture = "amd64",
+    architecture = select({
+        "@platforms//cpu:x86_64": "amd64",
+        "//conditions:default": "unknown",
+    }),
     data = ":bb_clientd_deb_data",
     depends = ["fuse"],
     description = "The Buildbarn client daemon",
     homepage = "https://github.com/buildbarn/bb-clientd",
     maintainer = "The Buildbarn team",
     package = "bb-clientd",
+    package_file_name = "bb-clientd.deb",
     postinst = "configs/linux/postinst.sh",
-    version = "0.0.0",
+    version_file = ":deb_version_file",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,11 +1,13 @@
 module(name = "com_github_buildbarn_bb_clientd")
 
+bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
 bazel_dep(name = "bazel_remote_apis", version = "0.0.0")
 bazel_dep(name = "com_github_buildbarn_bb_remote_execution")
 bazel_dep(name = "com_github_buildbarn_bb_storage")
 bazel_dep(name = "com_github_buildbarn_go_xdr")
 bazel_dep(name = "gazelle", version = "0.42.0")
 bazel_dep(name = "jsonnet_go", version = "0.20.0")
+bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "protobuf", version = "29.3")
 bazel_dep(name = "rules_jsonnet", version = "0.6.0")
 bazel_dep(name = "rules_go", version = "0.53.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -19,7 +19,8 @@
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/MODULE.bazel": "668e6bcb4d957fc0e284316dba546b705c8d43c857f87119619ee83c4555b859",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.13.0/MODULE.bazel": "af4a546cb88c618f2e241721d2d76b70b7ecfaa1d58fe27b9187d3edb9e418da",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.13.0/source.json": "5538ef77a1ecff41c119e040d4bc0148c83e9e79464a165ec86a1aa3171a5535",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/MODULE.bazel": "2b31ffcc9bdc8295b2167e07a757dbbc9ac8906e7028e5170a3708cecaac119f",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.14.0/source.json": "0cf1826853b0bef8b5cd19c0610d717500f5521aa2b38b72b2ec302ac5e7526c",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.7.2/MODULE.bazel": "780d1a6522b28f5edb7ea09630748720721dfe27690d65a2d33aa7509de77e07",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
@@ -113,7 +114,8 @@
     "https://bcr.bazel.build/modules/opentracing-cpp/1.6.0/MODULE.bazel": "b3925269f63561b8b880ae7cf62ccf81f6ece55b62cd791eda9925147ae116ec",
     "https://bcr.bazel.build/modules/opentracing-cpp/1.6.0/source.json": "da1cb1add160f5e5074b7272e9db6fd8f1b3336c15032cd0a653af9d2f484aed",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
-    "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
@@ -297,22 +299,6 @@
             "rules_cc+"
           ]
         ]
-      }
-    },
-    "@@platforms//host:extension.bzl%host_platform": {
-      "general": {
-        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
-        "usagesDigest": "6v1pzl9bOYnK0LhTceVpV/w3o/NwbbHwuORIyhzuWdk=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "host_platform": {
-            "repoRuleId": "@@platforms//host:extension.bzl%host_platform_repo",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": []
       }
     },
     "@@rules_antlr+//antlr:extensions.bzl%antlr": {
@@ -906,7 +892,7 @@
     },
     "@@rules_oci+//oci:extensions.bzl%oci": {
       "general": {
-        "bzlTransitiveDigest": "qNlcd8WTd4UyzUfM/zpvBIVgvreRoBqBDGhBZr2NxbY=",
+        "bzlTransitiveDigest": "3VHvN7yEizk2pPmT4szKumVABGp/C9KyQ+by3sQaFGg=",
         "usagesDigest": "XbJtglqxAiu1C72KSqr6iFRUYlrpuVMH48oWXbEHJIU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1177,6 +1163,12 @@
             "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
             "attributes": {
               "platform": "linux_arm64"
+            }
+          },
+          "copy_to_directory_linux_s390x": {
+            "repoRuleId": "@@aspect_bazel_lib+//lib/private:copy_to_directory_toolchain.bzl%copy_to_directory_platform_repo",
+            "attributes": {
+              "platform": "linux_s390x"
             }
           },
           "copy_to_directory_windows_amd64": {

--- a/configs/linux/postinst.sh
+++ b/configs/linux/postinst.sh
@@ -13,11 +13,20 @@ else
   # Restarting systemd-logind.service effectively kills user sessions and the
   # users' desktop environment, so let the user get a hint about reboot
   # instead.
-  /usr/share/update-notifier/notify-reboot-required
-  if [ -e /var/run/reboot-required ]; then
-    cat /var/run/reboot-required
+  if [ "$#" -ge 2 ] && [ "$1" = "configure" ]; then
+    old_version=$2
+  else
+    old_version=""
   fi
-  echo "Please reboot to apply changes to /etc/logind.conf"
+  # In the future, the old version can determine if reboot is required:
+  # if dpkg --compare-versions "$old_version" lt "20250312T094712Z-2b641c6"; then
+  if [ -z "$old_version" ]; then
+    /usr/share/update-notifier/notify-reboot-required
+    if [ -e /var/run/reboot-required ]; then
+      cat /var/run/reboot-required
+    fi
+    echo "Please reboot to apply changes to /etc/logind.conf"
+  fi
 fi
 
 # Pick up changes to the systemd service.

--- a/tools/github_workflows/github_workflows.jsonnet
+++ b/tools/github_workflows/github_workflows.jsonnet
@@ -12,7 +12,7 @@ workflows_template.getWorkflows(
         steps+: [
           {
             name: 'linux_amd64: build bb_clientd.deb',
-            run: 'bazel build --platforms=@rules_go//go/toolchain:linux_amd64 //:bb_clientd_deb',
+            run: 'bazel build --stamp --platforms=@rules_go//go/toolchain:linux_amd64 //:bb_clientd_deb',
           },
           {
             name: 'linux_amd64: copy bb_clientd.deb',


### PR DESCRIPTION
Instead of killing the user sessions and any desktop environments, notify the user about that a reboot is required to apply changes to `/etc/logind.conf`.

Also add version number to bb-clientd.deb and skip asking for reboot if just upgrading.

Fixes #25