### PR TITLE
Allow ~/.config/bb_clientd subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ journalctl --user -u bb_clientd -f
 
 By default, bb\_clientd will use the configuration file that is also
 shipped with this repository. It is possible to override configuration
-options by creating a file named `~/.config/bb_clientd.jsonnet` that
-uses the following structure:
+options by creating a file named `~/.config/bb_clientd/bb_clientd.jsonnet`
+that uses the following structure:
 
 ```jsonnet
 local defaultConfiguration = import 'bb_clientd_defaults.jsonnet';

--- a/configs/linux/launch_bb_clientd_linux.sh
+++ b/configs/linux/launch_bb_clientd_linux.sh
@@ -23,9 +23,19 @@ if [ "$1" = "start" ]; then
   # Use either the user provided or system-wide configuration file, based
   # on whether the former is present.
   config_file=/usr/lib/bb_clientd/bb_clientd.jsonnet
-  personal_config_file="${HOME}/.config/bb_clientd.jsonnet"
+  personal_config_file="${HOME}/.config/bb_clientd/bb_clientd.jsonnet"
+
+  # TODO: 2025-04-08 Remove migration code after a year.
+  old_personal_config_file="${HOME}/.config/bb_clientd.jsonnet"
+  if [ -f "$old_personal_config_file" ]; then
+    echo "Found ${old_personal_config_file}, moving it to ${personal_config_file}"
+    mkdir -p "${HOME}/.config/bb_clientd"
+    mv "$old_personal_config_file" "$personal_config_file"
+  fi
+  rm -f "${HOME}/.config/bb_clientd_defaults.jsonnet"
+
   if [ -f "${personal_config_file}" ]; then
-    ln -sf "${config_file}" "${HOME}/.config/bb_clientd_defaults.jsonnet"
+    ln -sf "${config_file}" "${HOME}/.config/bb_clientd/bb_clientd_defaults.jsonnet"
     config_file="${personal_config_file}"
   fi
 


### PR DESCRIPTION
When having multiple configuration files, the ~/.config directory gets cleaner when they are all gathered in the subdirectory bb_clientd. Adding an automatic migration for now to move bb_clientd.jsonnet from ~/.config/ into ~/.config/bb_clientd/. Note that any potential load statements might fail if those files are not moved.